### PR TITLE
Bug/es mapping mismatch

### DIFF
--- a/src/indexClinicalData/index.ts
+++ b/src/indexClinicalData/index.ts
@@ -16,8 +16,7 @@ export const queryDocumentsByDonorIds = async (
   const esQuery = esb
     .requestBodySearch()
     .size(donorIds.length)
-    // appending .keyword is required when using termquery/termsquery on a field that's been declared as type keyword in the mapping!
-    .query(esb.termsQuery("donorId.keyword", donorIds));
+    .query(esb.termsQuery("donorId", donorIds));
 
   const esHits: Array<EsHit> = await client
     .search({

--- a/src/indexClinicalData/unit.test.ts
+++ b/src/indexClinicalData/unit.test.ts
@@ -19,7 +19,7 @@ import {
   DonorMolecularDataReleaseStatus,
   RdpcDonorInfo,
 } from "./types";
-import { toEsBulkIndexActions } from "elasticsearch";
+import { initIndexMapping, toEsBulkIndexActions } from "elasticsearch";
 import { esDonorId } from "./utils";
 import { mean, range, random } from "lodash";
 
@@ -102,6 +102,7 @@ describe("indexing programs", () => {
     await esClient.indices.create({
       index: TARGET_ES_INDEX,
     });
+    await initIndexMapping(TARGET_ES_INDEX, esClient);
   });
   afterEach(async function () {
     await DonorSchema().deleteMany({});


### PR DESCRIPTION
Actually, `.keyword` is required if there is no mapping... the test was not set up to properly initialize the mapping, which is why it was passing before.

Had there been a similar test at a higher level, it would have failed. For now, I've adjusted the existing test and make the required change :)