### PR TITLE
Use library to validate JWT instead of custom logic

### DIFF
--- a/src/auth/egoTokenUtils.ts
+++ b/src/auth/egoTokenUtils.ts
@@ -6,12 +6,7 @@ import urljoin from "url-join";
 
 export default async () => {
   const egoPubliKey: string = await getPublicKey();
-  const TokenUtils = createEgoUtils(egoPubliKey);
-  return {
-    ...TokenUtils,
-    isExpiredToken: (decodedToken: ReturnType<typeof TokenUtils.decodeToken>) =>
-      decodedToken.exp < new Date().getUTCMilliseconds(),
-  };
+  return createEgoUtils(egoPubliKey);
 };
 
 const getPublicKey = async (): Promise<string> => {

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -25,18 +25,22 @@ type EgoAppCredential = {
 };
 
 export type EgoJwtManager = {
-  getLatestJwt: () => Promise<EgoAccessToken>;
+  getLatestJwt: (options: { noCache?: boolean }) => Promise<EgoAccessToken>;
 };
 
 export const createEgoJwtManager = async (): Promise<EgoJwtManager> => {
   let cachedJwt = await getJwt();
-  const getLatestJwt = async () => {
-    const egoTokenUtil = await createEgoUtil();
-    const decodedToken = egoTokenUtil.decodeToken(cachedJwt.access_token);
-    cachedJwt = egoTokenUtil.isExpiredToken(decodedToken)
-      ? await getJwt()
-      : cachedJwt;
-    return cachedJwt;
+  let egoTokenUtil = await createEgoUtil();
+  const getLatestJwt = async ({ noCache = false }) => {
+    switch (noCache) {
+      case true:
+        egoTokenUtil = await createEgoUtil();
+        return await getJwt();
+      case false:
+        const decodedToken = egoTokenUtil.decodeToken(cachedJwt.access_token);
+        cachedJwt = egoTokenUtil.isValidJwt() ? await getJwt() : cachedJwt;
+        return cachedJwt;
+    }
   };
   return { getLatestJwt };
 };

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -37,7 +37,6 @@ export const createEgoJwtManager = async (): Promise<EgoJwtManager> => {
         egoTokenUtil = await createEgoUtil();
         return await getJwt();
       case false:
-        const decodedToken = egoTokenUtil.decodeToken(cachedJwt.access_token);
         cachedJwt = egoTokenUtil.isValidJwt() ? await getJwt() : cachedJwt;
         return cachedJwt;
     }

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -25,7 +25,7 @@ type EgoAppCredential = {
 };
 
 export type EgoJwtManager = {
-  getLatestJwt: (options: { noCache?: boolean }) => Promise<EgoAccessToken>;
+  getLatestJwt: (options?: { noCache?: boolean }) => Promise<EgoAccessToken>;
 };
 
 export const createEgoJwtManager = async (): Promise<EgoJwtManager> => {


### PR DESCRIPTION
The logic in place to check for JWT expiry was checking against `new Date().getUTCMilliseconds()` to get the current time, which actually only returns the millisecond component of the new Date. Instead of worrying about getting our time checking correct we should use the tools available through tried and tested libraries, so now this uses `egoTokenUtil.isValidJwt()` and removes the `isExpiredToken(token)` method. Single reference to this has been updated.

I added a cache busting option to the `getLatestJwt()` method that defaults to `false`. If used, it will get a new JWT without checking for validity of the current one, and it will also fetch the Ego Public Key again. Currently, we are fetching the public key on every JWT check, which is much noisier than we require. This isn't used int he code anywhere yet but we can make use of this when doing retries caused by 'expired JWT' or other auth issues, just to ensure the service hasn't missed an update to the ego key.