### PR TITLE
No Clone on Sync Event

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -150,5 +150,12 @@ if (USE_VAULT && VAULT_AUTH_METHOD === "kubernetes") {
 
 export const MAX_RETRIES = Number(process.env.MAX_RETRIES) || 5;
 
+export const RETRY_CONFIG_RDPC_GATEWAY = {
+  factor: 2,
+  retries: MAX_RETRIES,
+  minTimeout: 1000,
+  maxTimeout: Infinity,
+};
+
 export const FEATURE_RDPC_INDEXING_ENABLED =
   process.env.FEATURE_RDPC_INDEXING_ENABLED === "true";

--- a/src/elasticsearch/index.ts
+++ b/src/elasticsearch/index.ts
@@ -137,3 +137,17 @@ export const getIndexSettings = async (
   })) as SettingsResponse;
   return response;
 };
+
+export const setIndexWritable = async (
+  esClient: Client,
+  indexName: string,
+  enabled: boolean
+): Promise<SettingsResponse> =>
+  await esClient.indices.putSettings({
+    index: indexName.toLowerCase(),
+    body: {
+      settings: {
+        "index.blocks.write": enabled,
+      },
+    },
+  });

--- a/src/elasticsearch/index.ts
+++ b/src/elasticsearch/index.ts
@@ -147,7 +147,9 @@ export const setIndexWritable = async (
     index: indexName.toLowerCase(),
     body: {
       settings: {
-        "index.blocks.write": enabled,
+        // This looks backwards, but if index.blocks.write is true then the index cannot be written to. it BLOCKS any writing
+        //  https://www.elastic.co/guide/en/elasticsearch/reference/master/index-modules-blocks.html
+        "index.blocks.write": !enabled,
       },
     },
   });

--- a/src/programQueueProcessor/eventProcessor.ts
+++ b/src/programQueueProcessor/eventProcessor.ts
@@ -172,6 +172,8 @@ const createEventProcessor = async ({
     const queuedEvent = JSON.parse(message.value.toString());
     const { programId } = queuedEvent;
 
+    statusReporter?.startProcessingProgram(programId);
+
     logger.info(`Begin processing event: ${queuedEvent.type} - ${programId}`);
 
     try {

--- a/src/programQueueProcessor/index.ts
+++ b/src/programQueueProcessor/index.ts
@@ -38,8 +38,8 @@ const createProgramQueueProcessor = async ({
   egoJwtManager,
   rollCallClient,
   statusReporter,
-  analysisFetcher = fetchAnalyses,
-  analysisWithSpecimensFetcher = fetchAnalysesWithSpecimens,
+  analysesFetcher = fetchAnalyses,
+  analysesWithSpecimensFetcher = fetchAnalysesWithSpecimens,
   fetchVC = fetchVariantCallingAnalyses,
   fetchDonorIds = fetchDonorIdsByAnalysis,
 }: {
@@ -48,8 +48,8 @@ const createProgramQueueProcessor = async ({
   rollCallClient: RollCallClient;
   egoJwtManager: EgoJwtManager;
   statusReporter?: StatusReporter;
-  analysisFetcher?: typeof fetchAnalyses;
-  analysisWithSpecimensFetcher?: typeof fetchAnalysesWithSpecimens;
+  analysesFetcher?: typeof fetchAnalyses;
+  analysesWithSpecimensFetcher?: typeof fetchAnalysesWithSpecimens;
   fetchVC?: typeof fetchVariantCallingAnalyses;
   fetchDonorIds?: typeof fetchDonorIdsByAnalysis;
 }): Promise<ProgramQueueProcessor> => {
@@ -93,8 +93,8 @@ const createProgramQueueProcessor = async ({
       esClient,
       egoJwtManager,
       rollCallClient,
-      analysisFetcher,
-      analysisWithSpecimensFetcher,
+      analysesFetcher,
+      analysesWithSpecimensFetcher,
       fetchVC,
       statusReporter,
       fetchDonorIds,

--- a/src/programQueueProcessor/index.ts
+++ b/src/programQueueProcessor/index.ts
@@ -91,7 +91,6 @@ const createProgramQueueProcessor = async ({
     partitionsConsumedConcurrently: PARTITIONS_CONSUMED_CONCURRENTLY,
     eachMessage: await createEventProcessor({
       esClient,
-      programQueueTopic,
       egoJwtManager,
       rollCallClient,
       analysisFetcher,

--- a/src/programQueueProcessor/unit.test.ts
+++ b/src/programQueueProcessor/unit.test.ts
@@ -321,8 +321,8 @@ describe("kafka integration", () => {
         esClient,
         rollCallClient: rollcallClient,
         egoJwtManager: mockEgoJwtManager,
-        analysisFetcher: mockAnalysisFetcher,
-        analysisWithSpecimensFetcher: mockAnalysesWithSpecimensFetcher,
+        analysesFetcher: mockAnalysisFetcher,
+        analysesWithSpecimensFetcher: mockAnalysesWithSpecimensFetcher,
         fetchVC: mockVariantCallingFetcher,
       });
 
@@ -655,8 +655,8 @@ describe("kafka integration", () => {
         esClient,
         egoJwtManager: mockEgoJwtManager,
         rollCallClient: rollcallClient,
-        analysisFetcher: mockAnalysisFetcher,
-        analysisWithSpecimensFetcher: mockAnalysesWithSpecimensFetcher,
+        analysesFetcher: mockAnalysisFetcher,
+        analysesWithSpecimensFetcher: mockAnalysesWithSpecimensFetcher,
         fetchVC: mockVariantCallingFetcher,
         fetchDonorIds: () => Promise.resolve([testDonorId]),
       });


### PR DESCRIPTION
The primary purpose of this PR is to cause the `eventProcessor` to get an empty index from RollCall on `SYNC` type events.  

To accomplish this there was one key functional change:
- `getNewResolvedIndex(...)` now takes an input argument to indicate if a clone of the existing index is desired. This method will make sure the returned index has the existing documents in it if `cloneExisting=true`

I did some cleanup along the way in an effort to make the log outputs consistent and the code a bit clearer. Some changes of note:
- Move the retry properties to the config file
- A switch for the event types in place of the if/else ladder
- Throwing an error immediately if the event has no message instead of nesting the method in an if-block
- Changing the names of several variables from `analysis*` to `analyses*` to keep variable names consistent.
- Export a method from the elasticsearch module called `setIndexWritable` to enable/disable the writable property of an index.

Some other small additions:
- After editing the new index, before releasing, update it to disable future writing.
- Since we were using `statusReporter` to send a message when processing was finished, I also added `statusReporter?.startProcessingProgram(programId);` at the start of event processing