### PR TITLE
More accurate response message for sync request

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,11 +67,15 @@ import { isNotEmptyString } from "utils";
           type: programQueueProcessor.knownEventTypes.SYNC,
           rdpcGatewayUrls: [RDPC_URL],
         });
-        return res.status(200).send(`program ${programId} has been indexed.`);
+        return res
+          .status(200)
+          .send(`Program ${programId} has been queued for indexing.`);
       }
     } catch (error) {
-      logger.error("error in processing index program request: " + error);
-      return res.status(500).send(`failed to index program ${programId}`);
+      logger.error("Error in processing index program request: " + error);
+      return res
+        .status(500)
+        .send(`Failed to queue program ${programId} for indexing`);
     }
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,7 @@ import { isNotEmptyString } from "utils";
       logger.error("Error in processing index program request: " + error);
       return res
         .status(500)
-        .send(`Failed to queue program ${programId} for indexing`);
+        .send(`Failed to queue program ${programId} for indexing.`);
     }
   });
 


### PR DESCRIPTION
No functional change, just changing to response message from the endpoint to request a re-index. It was confusing saying the indexing was done when it had only been queued for processing.