### PR TITLE
log a warning when workflow name is missing in sanger analysis

### DIFF
--- a/src/rdpc/variantCallingAnalysesProcessor.ts
+++ b/src/rdpc/variantCallingAnalysesProcessor.ts
@@ -187,7 +187,14 @@ const convertAnalysis = (
     const infoMapPerAnalysis = analysis.donors.reduce<
       StringMap<SangerAndMutectInfo>
     >((infoAccumulator, donor) => {
-      const workflowName = analysis.workflow.workflowName.toLocaleLowerCase();
+      let workflowName = "";
+      if (analysis.workflow && analysis.workflow.workflowName) {
+        workflowName = analysis.workflow.workflowName.toLocaleLowerCase();
+      } else {
+        logger.warn(`Incomplete RDPC Data: analysis id: ${analysis.analysisId} does not have 'workflow' or 'workflowname',
+        this analysis will not be indexed.`);
+      }
+
       const info: SangerAndMutectInfo = {
         sangerVC: [],
         mutect: [],
@@ -195,7 +202,7 @@ const convertAnalysis = (
 
       const workflowData = {
         analysisId: analysis.analysisId,
-        workflowName: analysis.workflow.workflowName,
+        workflowName: workflowName,
         firstPublishedAt: analysis.firstPublishedAt,
       };
 

--- a/src/rdpc/variantCallingAnalysesProcessor.ts
+++ b/src/rdpc/variantCallingAnalysesProcessor.ts
@@ -192,7 +192,7 @@ const convertAnalysis = (
         workflowName = analysis.workflow.workflowName.toLocaleLowerCase();
       } else {
         logger.warn(`Incomplete RDPC Data: analysis id: ${analysis.analysisId} does not have 'workflow' or 'workflowname',
-        this analysis will not be indexed.`);
+        this analysis won't be included in the donor's aggregated stats.`);
       }
 
       const info: SangerAndMutectInfo = {


### PR DESCRIPTION
A bug was found when indexing `test-pr` in qa: 
```
2021-06-23T20:01:53.112Z info: Begin processing event: SYNC - TEST-PR 
2021-06-23T20:01:54.826Z info: Obtaining new index, first for program. 
2021-06-23T20:01:59.990Z info: Obtained new index name: donor_centric_program_testpr_re_10963 
2021-06-23T20:02:02.209Z info: Enabled index writing for: donor_centric_program_testpr_re_10963 
2021-06-23T20:02:02.868Z info: streaming 2 donor(s) from chunk #0 of program TEST-PR duration: 458
2021-06-23T20:02:02.874Z info: Processing program: TEST-PR from https://api.rdpc-qa.cancercollaboratory.org/graphql. 
2021-06-23T20:02:02.879Z info: Fetching sequencing experiment analyses with specimens from rdpc..... 
2021-06-23T20:02:03.799Z info: Streaming 14 of sequencing_experiment analyses with specimens and samples... 
2021-06-23T20:02:03.801Z info: Fetching sequencing experiment analyses with specimens from rdpc..... 
2021-06-23T20:02:03.881Z info: Streaming 50 of variant calling analyses for sanger/mutect first published dates... 
2021-06-23T20:02:03.883Z warn: Failed to index program TEST-PR on attempt #1: TypeError: Cannot read property 'toLocaleLowerCase' of null 
2021-06-23T20:02:06.666Z info: Index was removed: donor_centric_program_testpr_re_10963 
2021-06-23T20:02:07.674Z info: Obtaining new index, first for program. 
2021-06-23T20:02:11.068Z info: Obtained new index name: donor_centric_program_testpr_re_10963 
2021-06-23T20:02:12.608Z info: Enabled index writing for: donor_centric_program_testpr_re_10963 
2021-06-23T20:02:13.105Z info: streaming 2 donor(s) from chunk #0 of program TEST-PR duration: 487
2021-06-23T20:02:13.114Z info: Processing program: TEST-PR from https://api.rdpc-qa.cancercollaboratory.org/graphql. 
2021-06-23T20:02:13.114Z info: Fetching sequencing experiment analyses with specimens from rdpc..... 
2021-06-23T20:02:13.162Z info: Streaming 14 of sequencing_experiment analyses with specimens and samples... 
2021-06-23T20:02:13.163Z info: Fetching sequencing experiment analyses with specimens from rdpc..... 
2021-06-23T20:02:13.251Z info: Streaming 50 of variant calling analyses for sanger/mutect first published dates... 
2021-06-23T20:02:13.252Z warn: Failed to index program TEST-PR on attempt #2: TypeError: Cannot read property 'toLocaleLowerCase' of null 
2021-06-23T20:02:13.945Z info: Index was removed: donor_centric_program_testpr_re_10963 
2021-06-23T20:02:15.965Z info: Obtaining new index, first for program. 
```

The cause was that `workflowname` was null in rdpc: 
```
{
          "analysisId": "08d245c8-caf0-4264-9245-c8caf07264a0",
          "analysisType": "variant_calling",
          "firstPublishedAt": "1606929512353",
          "workflow": {
            "workflowName": null
          },
          "donors": [
            {
              "donorId": "DO250183"
            }
          ]
        },
```
This broke aggregator as it was expecting a value: 
`      const workflowName = analysis.workflow.workflowName.toLocaleLowerCase();`

This PR fixes it by logging a warning when workflow name is null in analysis. 