### PR TITLE
fetch donor id by analysis id only

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ For local devlopment, you can post messages to trigger indexing:
 }
 ```
 
-- for `song_analysis`, make a `POST` request to `http://localhost:8082/topics/song_analysis`, request body can be:
+- for `song_analysis`, there are 2 types of messages:
+- Type 1:
+  - Message to index the entire program
+  - How to post a test message: make a `POST` request to `http://localhost:8082/topics/song_analysis`, must provide `studyId` and `type` in request body:
 
 ```
 {
@@ -53,23 +56,46 @@ For local devlopment, you can post messages to trigger indexing:
            "studyId": "PACA-CA"
        }
    }
-
  ]
+}
+```
+
+- Type 2: Incremental update:
+  - Message to update certain donors within a program
+  - Must include `studyId`, `analysisId` in the request body
+
+```
+{
+"records":
+[
+  {
+      "key": "ROSI-RU",
+      "value": {
+          "analysisId": "6e2cdfbe-59bb-4c7c-acdf-be59bb7c7c26",
+          "studyId" : "ROSI-RU",
+          "state" : "UNPUBLISHED",
+          "action" : "PUBLISH",
+          "songServerId" : "song.collab"
+      }
+  }
+]
 }
 ```
 
 - for `donor_aggregator_program_queues`, a sample message looks like:
 
 ```
+
 {
-   "topic": "donor_aggregator_program_queues",
-   "key": "OCCAMS-GB",
-   "value": "{
-     "programId":"OCCAMS-GB",
-     "type":"SYNC",
-     "rdpcGatewayUrls": ["https://api.rdpc.cancercollaboratory.org/graphql"]
-     }",
- }
+"topic": "donor_aggregator_program_queues",
+"key": "OCCAMS-GB",
+"value": "{
+"programId":"OCCAMS-GB",
+"type":"SYNC",
+"rdpcGatewayUrls": ["https://api.rdpc.cancercollaboratory.org/graphql"]
+}",
+}
+
 ```
 
 - Topic `donor_aggregator_program_queues` stores messages collected from `PROGRAM_UPDATE` and `song_analysis`.
@@ -82,7 +108,9 @@ For local devlopment, you can post messages to trigger indexing:
 
 This event is published by argo-clinical service, donor aggregator listens to topic `PROGRAM_UPDATE` for new events and starts indexing the program clinical data.
 
-- RDPC
+-
+
+* RDPC
 
 This event is published by RDPC, donor aggregator listens to topic `song_analysis` for new events and starts querying RDPC API for analyses data, when complete, it starts indexing the entire program if no `analysis_id` is provided in the message.
 

--- a/src/eventParsers/parseRdpcProgramUpdateEvent.ts
+++ b/src/eventParsers/parseRdpcProgramUpdateEvent.ts
@@ -1,5 +1,4 @@
 import logger from "logger";
-import { Action } from "rdpc/query/types";
 import { isNotAbsent } from "utils";
 
 const parseRdpcProgramUpdateEvent = (
@@ -10,7 +9,7 @@ const parseRdpcProgramUpdateEvent = (
     return obj;
   } else {
     logger.warn(
-      "Failed to process message. Message must have studyId, and/or analysisId + action, it's either not a RDPC update event or message has invalid/missing fields."
+      "Failed to process message. Message must have studyId, and/or analysisId, it's either not a RDPC update event or message has invalid/missing fields."
     );
     return {
       studyId: "",
@@ -28,7 +27,6 @@ type RdpcProgramUpdateEvent = {
   studyId: string;
   state?: RDPC_EVENT_STATE;
   analysisId?: string;
-  action?: Action;
 };
 
 const isProgramUpdateEvent = (
@@ -38,16 +36,6 @@ const isProgramUpdateEvent = (
     const event = data as RdpcProgramUpdateEvent;
 
     if (isNotAbsent(event.studyId) && typeof event.studyId === "string") {
-      // analysisId and action are optional in the message,
-      // when they are not present, only studyId is required for indexing the entire program,
-      // when they are present, hey must both exist as they are needed
-      // for fetchDonorIdsByAnalysis.
-      if (
-        (isNotAbsent(event.analysisId) && !isNotAbsent(event.action)) ||
-        (!isNotAbsent(event.analysisId) && isNotAbsent(event.action))
-      ) {
-        return false;
-      }
       return true;
     }
     return false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,9 @@ import { isNotEmptyString } from "utils";
     partitionsConsumedConcurrently: PARTITIONS_CONSUMED_CONCURRENTLY,
     eachMessage: async ({ topic, message }) => {
       logger.info(`received event from topic ${topic}`);
+      logger.debug(
+        `message offset: ${message.offset} in topic ${topic}, message timestamp: ${message.timestamp}`
+      );
       if (message && message.value) {
         switch (topic) {
           case CLINICAL_PROGRAM_UPDATE_TOPIC:
@@ -154,7 +157,6 @@ import { isNotEmptyString } from "utils";
                   type: programQueueProcessor.knownEventTypes.RDPC,
                   rdpcGatewayUrls: [RDPC_URL],
                   analysisId: event.analysisId,
-                  action: event.action,
                 });
               } else {
                 await programQueueProcessor.sendDlqMessage(

--- a/src/programQueueProcessor/eventProcessor.ts
+++ b/src/programQueueProcessor/eventProcessor.ts
@@ -226,7 +226,6 @@ const createEventProcessor = async ({
                   fetchVC,
                   fetchDonorIds,
                   analysisId: queuedEvent.analysisId,
-                  action: queuedEvent.action,
                 });
               }
               break;

--- a/src/programQueueProcessor/index.ts
+++ b/src/programQueueProcessor/index.ts
@@ -68,6 +68,7 @@ const createProgramQueueProcessor = async ({
 
   const enqueueEvent = async (event: QueueRecord) => {
     await producer.send(createProgramQueueRecord(event));
+    logger.debug(`enqueuing event: ${JSON.stringify(event)}`);
     logger.info(`enqueued ${event.type} event for program ${event.programId}`);
   };
 

--- a/src/programQueueProcessor/types.ts
+++ b/src/programQueueProcessor/types.ts
@@ -11,7 +11,6 @@ export type QueueRecord = { programId: string; requeued?: boolean } & (
       type: KnownEventType.RDPC;
       rdpcGatewayUrls: Array<string>;
       analysisId?: string;
-      action?: string;
     }
   | {
       type: KnownEventType.SYNC;

--- a/src/programQueueProcessor/unit.test.ts
+++ b/src/programQueueProcessor/unit.test.ts
@@ -30,7 +30,6 @@ import donorIndexMapping from "elasticsearch/donorIndexMapping.json";
 import { generateIndexName } from "./util";
 import { getIndexSettings, getLatestIndexName } from "elasticsearch";
 import { EgoAccessToken, EgoJwtManager } from "auth";
-import { Action } from "rdpc/query/types";
 import {
   mockAnalysesWithSpecimensFetcher,
   mockAnalysisFetcher,
@@ -605,7 +604,6 @@ describe("kafka integration", () => {
         type: programQueueProcessor.knownEventTypes.RDPC,
         rdpcGatewayUrls: [""], // the urls don't matter since we're mocking all the rdpc fetchers
         analysisId: testAnalysis.analysisId,
-        action: Action.PUBLISH,
       });
 
       // wait for indexing to complete

--- a/src/rdpc/index.ts
+++ b/src/rdpc/index.ts
@@ -38,7 +38,6 @@ export const indexRdpcData = async ({
   fetchVC = fetchVariantCallingAnalyses,
   fetchDonorIds = fetchDonorIdsByAnalysis,
   analysisId,
-  action,
 }: {
   programId: string;
   rdpcUrl: string;
@@ -49,21 +48,18 @@ export const indexRdpcData = async ({
   fetchVC?: typeof fetchVariantCallingAnalyses; // optional only for test
   analysesWithSpecimensFetcher?: typeof fetchAnalysesWithSpecimens; // optional only for test
   analysisId?: string;
-  action?: string;
   fetchDonorIds?: typeof fetchDonorIdsByAnalysis;
 }) => {
   logger.info(`Processing program: ${programId} from ${rdpcUrl}.`);
   const config = { chunkSize: STREAM_CHUNK_SIZE };
 
-  const donorIdsToFilterBy =
-    analysisId && action
-      ? await fetchDonorIds({
-          rdpcUrl,
-          analysisId,
-          action,
-          egoJwtManager,
-        })
-      : undefined;
+  const donorIdsToFilterBy = analysisId
+    ? await fetchDonorIds({
+        rdpcUrl,
+        analysisId,
+        egoJwtManager,
+      })
+    : undefined;
 
   // contains 3 fields:
   // publishedNormalAnalysis, publishedTumourAnalysis, rawReadsFirstPublishedDate

--- a/src/rdpc/query/fetchDonorIdsByAnalysis.ts
+++ b/src/rdpc/query/fetchDonorIdsByAnalysis.ts
@@ -52,7 +52,6 @@ const fetchDonorIdsByAnalysis = async ({
           analysisId,
         } as QueryVariable,
       });
-      logger.info(`fetchDonorIdsByAnalysis: RDPC API Request body: ${body}`);
       const output = await fetch(rdpcUrl, {
         method: "POST",
         headers: {
@@ -63,9 +62,6 @@ const fetchDonorIdsByAnalysis = async ({
       })
         .then((res) => {
           const jsonResponse = res.json();
-          logger.info(
-            `RDPC-API Response for analisys: ${JSON.stringify(jsonResponse)}`
-          );
           return jsonResponse;
         })
         .then((res: { data: QueryResponseData }) => {

--- a/src/rdpc/query/types.ts
+++ b/src/rdpc/query/types.ts
@@ -15,9 +15,3 @@ export type QueryVariable = {
   analysisPage: PageQueryVar;
   workflowRepoUrl?: string;
 };
-
-export enum Action {
-  PUBLISH = "PUBLISH",
-  UNPUBLISH = "UNPUBLISH",
-  SUPPRESS = "SUPPRESS",
-}


### PR DESCRIPTION
This PR fixes the bug where a song_analysis event is received and the `action` in the message is not publish, unpublish, or suppress, donor aggregator sends empty string as `analysis_state` to query analysis. 
- When getting donor id, we should use analysis id without analysis state. 
- More debug logging is added to log out messages.