### PR TITLE
fix for aggregator failing to get new valid jwt

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -38,6 +38,7 @@ export const createEgoJwtManager = async (): Promise<EgoJwtManager> => {
         return await getJwt();
       case false:
         const isTokenValid = egoTokenUtil.isValidJwt(cachedJwt.access_token);
+        // todo remove loggings once jwt issue is gone.
         logger.info(`Is current JWT token valid? ${isTokenValid}`);
         isTokenValid
           ? logger.info(

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -37,7 +37,14 @@ export const createEgoJwtManager = async (): Promise<EgoJwtManager> => {
         egoTokenUtil = await createEgoUtil();
         return await getJwt();
       case false:
-        cachedJwt = egoTokenUtil.isValidJwt() ? await getJwt() : cachedJwt;
+        const isTokenValid = egoTokenUtil.isValidJwt(cachedJwt.access_token);
+        logger.info(`Is current JWT token valid? ${isTokenValid}`);
+        isTokenValid
+          ? logger.info(
+              `Current JWT is valid, expiring in ${cachedJwt.expires_in} seconds.`
+            )
+          : logger.info(`Current JWT is invalid, getting a new JWT...`);
+        cachedJwt = isTokenValid ? cachedJwt : await getJwt();
         return cachedJwt;
     }
   };


### PR DESCRIPTION
Aggregator should always get a new jwt when the current jwt becomes invalid. 