### PR TITLE
Prevent Kafka Consumer disconnection from long running processor

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -86,14 +86,21 @@ export const KAFKA_PROGRAM_QUEUE_TOPIC =
 export const DLQ_TOPIC_NAME =
   process.env.DLQ_TOPIC_NAME || "donor_aggregator_dlq";
 
+// Default 12*1000 = 12 seconds
 export const KAFKA_PROGRAM_QUEUE_CONSUMER_HEARTBEAT_INTERVAL =
-  process.env.KAFKA_PROGRAM_QUEUE_CONSUMER_HEARTBEAT_INTERVAL || 12 * 1000;
+  Number(process.env.KAFKA_PROGRAM_QUEUE_CONSUMER_HEARTBEAT_INTERVAL) ||
+  12 * 1000;
 
+// Default 120*1000 = 2 minutes, allows 1/10 heartbeat successes to stay connected
 export const KAFKA_PROGRAM_QUEUE_CONSUMER_SESSION_TIMEOUT =
-  process.env.KAFKA_PROGRAM_QUEUE_CONSUMER_SESSION_TIMEOUT || 120 * 1000;
+  Number(process.env.KAFKA_PROGRAM_QUEUE_CONSUMER_SESSION_TIMEOUT) ||
+  120 * 1000;
 
+// Default 240*1000 = 4 minutes. Rebalance is the time kafka will wait for consumer to reconnect while rebalancing.
+// If you are experiencing long startup times waiting for kafka connection, this is the likely culprit.
 export const KAFKA_PROGRAM_QUEUE_CONSUMER_REBALANCE_TIMEOUT =
-  process.env.KAFKA_PROGRAM_QUEUE_CONSUMER_REBALANCE_TIMEOUT || 240 * 1000;
+  Number(process.env.KAFKA_PROGRAM_QUEUE_CONSUMER_REBALANCE_TIMEOUT) ||
+  240 * 1000;
 
 export const KAFKA_PROGRAM_QUEUE_CONSUMER_GROUP =
   process.env.KAFKA_PROGRAM_QUEUE_CONSUMER_GROUP ||
@@ -109,10 +116,9 @@ const kafkaBrokers = process.env.KAFKA_BROKERS
 export const KAFKA_BROKERS = kafkaBrokers.length
   ? kafkaBrokers
   : ["localhost:9092"];
-export const PARTITIONS_CONSUMED_CONCURRENTLY = process.env
-  .PARTITIONS_CONSUMED_CONCURRENTLY
-  ? Number(process.env.PARTITIONS_CONSUMED_CONCURRENTLY)
-  : 10;
+export const PARTITIONS_CONSUMED_CONCURRENTLY = Number(
+  process.env.PARTITIONS_CONSUMED_CONCURRENTLY || 5
+);
 export const KAFKA_PROGRAM_QUEUE_TOPIC_PARTITIONS = Number(
   process.env.KAFKA_PROGRAM_QUEUE_TOPIC_PARTITIONS || 5
 );

--- a/src/programQueueProcessor/eventProcessor.ts
+++ b/src/programQueueProcessor/eventProcessor.ts
@@ -303,8 +303,10 @@ const createEventProcessor = ({
 
         await setIndexWritable(esClient, targetIndexName, false);
         logger.info(`Disabled index writing for: ${targetIndexName}`);
+        statusReporter?.endProcessingProgram(programId);
       }, RETRY_CONFIG_RDPC_GATEWAY);
     } catch (err) {
+      statusReporter?.endProcessingProgram(programId);
       logger.error(
         `Failed to index program ${programId} after ${
           RETRY_CONFIG_RDPC_GATEWAY.retries
@@ -313,8 +315,6 @@ const createEventProcessor = ({
       );
       // Message processing failed, make sure it is sent to the Dead Letter Queue.
       sendDlqMessage(DLQ_TOPIC_NAME, message.value.toString());
-    } finally {
-      statusReporter?.endProcessingProgram(programId);
     }
   };
 };

--- a/src/programQueueProcessor/eventProcessor.ts
+++ b/src/programQueueProcessor/eventProcessor.ts
@@ -303,10 +303,8 @@ const createEventProcessor = ({
 
         await setIndexWritable(esClient, targetIndexName, false);
         logger.info(`Disabled index writing for: ${targetIndexName}`);
-        statusReporter?.endProcessingProgram(programId);
       }, RETRY_CONFIG_RDPC_GATEWAY);
     } catch (err) {
-      statusReporter?.endProcessingProgram(programId);
       logger.error(
         `Failed to index program ${programId} after ${
           RETRY_CONFIG_RDPC_GATEWAY.retries
@@ -315,6 +313,8 @@ const createEventProcessor = ({
       );
       // Message processing failed, make sure it is sent to the Dead Letter Queue.
       sendDlqMessage(DLQ_TOPIC_NAME, message.value.toString());
+    } finally {
+      statusReporter?.endProcessingProgram(programId);
     }
   };
 };

--- a/src/programQueueProcessor/index.ts
+++ b/src/programQueueProcessor/index.ts
@@ -58,9 +58,9 @@ const createProgramQueueProcessor = async ({
 }): Promise<ProgramQueueProcessor> => {
   const consumer = kafka.consumer({
     groupId: KAFKA_PROGRAM_QUEUE_CONSUMER_GROUP,
-    heartbeatInterval: Number(KAFKA_PROGRAM_QUEUE_CONSUMER_HEARTBEAT_INTERVAL),
-    sessionTimeout: Number(KAFKA_PROGRAM_QUEUE_CONSUMER_SESSION_TIMEOUT),
-    rebalanceTimeout: Number(KAFKA_PROGRAM_QUEUE_CONSUMER_REBALANCE_TIMEOUT),
+    heartbeatInterval: KAFKA_PROGRAM_QUEUE_CONSUMER_HEARTBEAT_INTERVAL,
+    sessionTimeout: KAFKA_PROGRAM_QUEUE_CONSUMER_SESSION_TIMEOUT,
+    rebalanceTimeout: KAFKA_PROGRAM_QUEUE_CONSUMER_REBALANCE_TIMEOUT,
   });
   const producer = kafka.producer();
   const programQueueTopic = await initializeProgramQueueTopic(kafka);
@@ -93,7 +93,7 @@ const createProgramQueueProcessor = async ({
 
   await consumer.run({
     partitionsConsumedConcurrently: PARTITIONS_CONSUMED_CONCURRENTLY,
-    eachMessage: await createEventProcessor({
+    eachMessage: createEventProcessor({
       esClient,
       egoJwtManager,
       rollCallClient,


### PR DESCRIPTION
Need to remove the await on the sync event processor. In order to keep the statusReporter in sync, those end processing calls are moved within the retry mechanism.

The kafka consumer heartbeat seems to be stopped as the `eachMessage` run method is awaiting a return. From the reading online, this isn't how I expect it to behave but local testing demonstrates this clearly. As a general rule, if the processor is longer than the heartbeat interval but less than the session interval, it will disconnect on first run, but will then run a second time when the consumer reconnects and complete successfully. If the process is longer than the SESSION timeout, then it will restart indefinitely and never conclude.

As best practice, we can use kafka to trigger the event and immediately mark it as complete as soon as we initiate the process. On fail, it will be a new message added to the DLQ indicating further action is required.

As a next step, we aren't preventing multiple instances of this application from running an update on the same program in parallel. For SYNC this won't matter, since in both cases this will just re-write the entire index. For incremental tasks this could cause data mismatch vs live (requiring a sync action to correct).