### PR TITLE
Fix shape of Ego Credentials in Vault

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -104,21 +104,6 @@ export const OPEN_ACCESS_REPO_URL =
  */
 export const KAFKA_PROGRAM_QUEUE_TOPIC =
   process.env.KAFKA_PROGRAM_QUEUE_TOPIC || "donor_aggregator_program_queues";
-// Default 12*1000 = 12 seconds
-const KAFKA_PROGRAM_QUEUE_CONSUMER_HEARTBEAT_INTERVAL =
-  Number(process.env.KAFKA_PROGRAM_QUEUE_CONSUMER_HEARTBEAT_INTERVAL) ||
-  12 * 1000;
-
-// Default 120*1000 = 2 minutes, allows 1/10 heartbeat successes to stay connected
-const KAFKA_PROGRAM_QUEUE_CONSUMER_SESSION_TIMEOUT =
-  Number(process.env.KAFKA_PROGRAM_QUEUE_CONSUMER_SESSION_TIMEOUT) ||
-  120 * 1000;
-
-// Default 240*1000 = 4 minutes. Rebalance is the time kafka will wait for consumer to reconnect while rebalancing.
-// If you are experiencing long startup times waiting for kafka connection, this is the likely culprit.
-const KAFKA_PROGRAM_QUEUE_CONSUMER_REBALANCE_TIMEOUT =
-  Number(process.env.KAFKA_PROGRAM_QUEUE_CONSUMER_REBALANCE_TIMEOUT) ||
-  240 * 1000;
 
 const DLQ_TOPIC_NAME = process.env.DLQ_TOPIC_NAME || "donor_aggregator_dlq";
 

--- a/src/external/ego/utils.ts
+++ b/src/external/ego/utils.ts
@@ -1,4 +1,5 @@
 import egoTokenUtils from "@icgc-argo/ego-token-utils";
+import _ from "lodash";
 import fetch from "node-fetch";
 import urlJoin from "url-join";
 import {
@@ -137,8 +138,5 @@ export const getEgoAppCredentials = async (
 const isEgoCredential = (obj: {
   [k: string]: any;
 }): obj is EgoApplicationCredential => {
-  return (
-    typeof obj["egoClientId"] === "string" &&
-    typeof obj["egoClientSecret"] === "string"
-  );
+  return _.isString(obj.clientId) && _.isString(obj.clientSecret);
 };


### PR DESCRIPTION
At deployment time, Vault credentials for ego apps need to:
A) seperate into RDPC and DCC credentials (if different, like staging)
B) change from `egoClientId`->`clientId` and from `egoClientSecret`->`clientSecret`