### PR TITLE
🩹 Update `ClinicalProgramUpdateEvent` Type (argo-clinical#601)

### DIFF
--- a/src/external/kafka/consumers/eventParsers/parseClinicalProgramUpdateEvent.ts
+++ b/src/external/kafka/consumers/eventParsers/parseClinicalProgramUpdateEvent.ts
@@ -1,5 +1,5 @@
 import logger from "logger";
-import { isNotAbsent } from "utils";
+import { isObjectLike, isString, isArray } from "lodash";
 
 type ClinicalProgramUpdateEvent = {
   programId: string;
@@ -7,15 +7,17 @@ type ClinicalProgramUpdateEvent = {
 };
 
 const isProgramUpdateEvent = (
-  data: unknown
-): data is ClinicalProgramUpdateEvent => {
-  if (data && typeof data === "object") {
-    const event = data as ClinicalProgramUpdateEvent;
-
-    if (isNotAbsent(event.programId) && typeof event.programId === "string") {
-      return true;
-    }
-    return false;
+  input: unknown
+): input is ClinicalProgramUpdateEvent => {
+  if (input && isObjectLike(input)) {
+    const event = input as ClinicalProgramUpdateEvent;
+    return (
+      isString(event.programId) &&
+      // donorIds is undefined or an array with all strings
+      (event.donorIds === undefined ||
+        (isArray(event.donorIds) &&
+          (event.donorIds as any[]).every((i) => isString(i))))
+    );
   }
   return false;
 };

--- a/src/external/kafka/consumers/eventParsers/parseClinicalProgramUpdateEvent.ts
+++ b/src/external/kafka/consumers/eventParsers/parseClinicalProgramUpdateEvent.ts
@@ -1,17 +1,19 @@
 import logger from "logger";
+import { isNotAbsent } from "utils";
 
 type ClinicalProgramUpdateEvent = {
   programId: string;
+  donorSubmitterId?: string;
 };
 
 const isProgramUpdateEvent = (
   data: unknown
 ): data is ClinicalProgramUpdateEvent => {
-  if (typeof data === "object") {
-    if (data) {
-      return (
-        data && typeof (data as { programId: string })["programId"] === "string"
-      );
+  if (data && typeof data === "object") {
+    const event = data as ClinicalProgramUpdateEvent;
+
+    if (isNotAbsent(event.programId) && typeof event.programId === "string") {
+      return true;
     }
     return false;
   }

--- a/src/external/kafka/consumers/eventParsers/parseClinicalProgramUpdateEvent.ts
+++ b/src/external/kafka/consumers/eventParsers/parseClinicalProgramUpdateEvent.ts
@@ -3,7 +3,7 @@ import { isNotAbsent } from "utils";
 
 type ClinicalProgramUpdateEvent = {
   programId: string;
-  donorSubmitterId?: string;
+  donorIds?: string[];
 };
 
 const isProgramUpdateEvent = (


### PR DESCRIPTION
Updates `ClinicalProgramUpdateEvent` Type to prevent breaking after changes from https://github.com/icgc-argo/argo-clinical/issues/601

Adds optional `donorIds` string array, changes `isProgramUpdateEvent` check to work with old and new clinical program update events.