### PR TITLE
New Consumer Groups join topic at end

### DIFF
--- a/src/external/kafka/createConsumer.ts
+++ b/src/external/kafka/createConsumer.ts
@@ -32,6 +32,7 @@ function createConsumer(
       rebalanceTimeout: config.rebalanceTimeout,
     });
     consumer.subscribe({
+      fromBeginning: false,
       topic: config.topic,
     });
     await consumer.connect();


### PR DESCRIPTION
Sets `fromBeginning: false` for all kafka consumers. This results in new consumer groups, when first created, will join the topic at the final offset, not from the beginning. Without this, the aggregator will rapidly repeat all the data update events which sends too many requests to ES in too short a time and will crash it.

This is really important to have in the code for whenever the consumer group names are changed.

Note that this will not change the consumer group offset when he service is restarted if the consumer group name remains the same. It will pick up all messages received while the service was offline.